### PR TITLE
#14: S3 bucket for lambda source code artifacts

### DIFF
--- a/modules/aws-s3-bucket/main.tf
+++ b/modules/aws-s3-bucket/main.tf
@@ -1,0 +1,11 @@
+resource "aws_s3_bucket" "self" {
+  bucket = "weberc2-${var.name}"
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "aws:kms"
+      }
+    }
+  }
+}

--- a/modules/aws-s3-bucket/outputs.tf
+++ b/modules/aws-s3-bucket/outputs.tf
@@ -1,0 +1,3 @@
+output "bucket" {
+  value = aws_s3_bucket.self
+}

--- a/modules/aws-s3-bucket/variables.tf
+++ b/modules/aws-s3-bucket/variables.tf
@@ -1,0 +1,9 @@
+variable "name" {
+  type        = string
+  description = "(Required) The name of the S3 bucket."
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "(Required) The tags to associate with the S3 bucket."
+}

--- a/modules/workload/outputs.tf
+++ b/modules/workload/outputs.tf
@@ -1,0 +1,11 @@
+output "name" {
+  value = "${var.environment}-${var.system}"
+}
+
+output "tags" {
+  value = merge({
+    environment = var.environment
+    management  = "terraform"
+    system      = var.system
+  }, var.additional_tags)
+}

--- a/modules/workload/variables.tf
+++ b/modules/workload/variables.tf
@@ -1,0 +1,15 @@
+variable "environment" {
+  type        = string
+  description = "The environment with which the tagged resources are associated."
+}
+
+variable "system" {
+  type        = string
+  description = "The system name."
+}
+
+variable "additional_tags" {
+  type        = map(string)
+  description = "(Optional) Additional tags. Defaults to `{}`"
+  default     = {}
+}

--- a/targets/bootstrap/main.tf
+++ b/targets/bootstrap/main.tf
@@ -15,10 +15,13 @@ resource "aws_s3_bucket" "state" {
 }
 
 resource "aws_dynamodb_table" "lock" {
-  name           = "TerraformStateLock"
-  hash_key       = "LockID"
-  read_capacity  = 25
-  write_capacity = 25
+  name     = "TerraformStateLock"
+  hash_key = "LockID"
+
+  # I only get 25 free capacity units each month for both reading and writing,
+  # so I don't want to use them all here.
+  read_capacity  = 4
+  write_capacity = 4
 
 
   attribute {

--- a/targets/lambda/.terraform.lock.hcl
+++ b/targets/lambda/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "3.37.0"
+  hashes = [
+    "h1:RvLGIfRZfbzY58wUja9B6CvGdgVVINy7zLVBdLqIelA=",
+    "zh:064c9b21bcd69be7a8631ccb3eccb8690c6a9955051145920803ef6ce6fc06bf",
+    "zh:277dd05750187a41282cf6e066e882eac0dd0056e3211d125f94bf62c19c4b8b",
+    "zh:47050211f72dcbf3d99c82147abd2eefbb7238efb94d5188979f60de66c8a3df",
+    "zh:4a4e0d070399a050847545721dae925c192a2d6354802fdfbea73769077acca5",
+    "zh:4cbc46f79239c85d69389f9e91ca9a9ebf6a8a937cfada026c5a037fd09130fb",
+    "zh:6548dcb1ac4a388ed46034a5317fa74b3b0b0f68eec03393f2d4d09342683f95",
+    "zh:75b4a82596aa525d95b0b2847fe648368c6e2b054059c4dc4dcdee01d374b592",
+    "zh:75cf5cc674b61c82300667a82650f56722618b119ab0526b47b5ecbb4bbf49d0",
+    "zh:93c896682359039960c38eb5a4b29d1cc06422f228db0572b90330427e2a21ec",
+    "zh:c7256663aedbc9de121316b6d0623551386a476fc12b8eb77e88532ce15de354",
+    "zh:e995c32f49c23b5938200386e08b2a3fd69cf5102b5299366c0608bbeac68429",
+  ]
+}

--- a/targets/lambda/main.tf
+++ b/targets/lambda/main.tf
@@ -1,0 +1,11 @@
+module "workload" {
+  source      = "../../modules/workload"
+  environment = "inf"
+  system      = "lambda"
+}
+
+module "bucket" {
+  source = "../../modules/aws-s3-bucket"
+  name   = "${module.workload.name}-code-artifacts"
+  tags   = module.workload.tags
+}

--- a/targets/lambda/terraform.tf
+++ b/targets/lambda/terraform.tf
@@ -1,0 +1,11 @@
+terraform {
+  backend "s3" {
+    bucket = "weberc2-terraform-state"
+    key    = "targets/lambda"
+    region = "us-east-2"
+  }
+}
+
+provider "aws" {
+  region = "us-east-2"
+}


### PR DESCRIPTION
* Created new aws-s3-bucket module for bucket defaults
* Created workload module for workload-common things
* Reduced the provisioned read/write capacity for Terraform state lock table