### PR TITLE
#15: replaced '${project}' interpolation with project name prefixing

### DIFF
--- a/.github/workflows/generate-workflows-check.yaml
+++ b/.github/workflows/generate-workflows-check.yaml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
       - name: Run script
-        run: pushd scripts/generate-workflows && go run .; popd
+        run: (cd scripts/generate-workflows && go run .)
       - name: Check diff
         run: |
           if [[ -n "$(git diff .github/workflows)" ]]; then


### PR DESCRIPTION
* Minor tweak to the 'go run ...' bit of the generate-workflows-check script